### PR TITLE
Speedup dos2unix.

### DIFF
--- a/git_filter_tree/dos2unix.py
+++ b/git_filter_tree/dos2unix.py
@@ -34,14 +34,16 @@ class Dos2Unix(TreeFilter):
 
     async def convertToUnix(self, obj):
         text = await self.read_blob(obj.sha1)
-        lines = text.decode('utf-8').splitlines()
-        while len(lines) > 0 and lines[-1] == '':
+        if text.find(b"\r") == -1 and text.find(b" \n") == -1:
+            return obj.sha1
+        lines = text.splitlines()
+        while len(lines) > 0 and lines[-1].rstrip() == b"":
             lines.pop()
         if len(lines) > 0:
-            content =  "\n".join(line.rstrip() for line in lines) + "\n"
+            content =  b"\n".join(map(bytes.rstrip, lines)) + b"\n"
         else:
-            content = ""
-        return await self.write_blob(content.encode('utf-8'))
+            content = b""
+        return await self.write_blob(content)
 
 main = Dos2Unix.main
 if __name__ == '__main__':

--- a/git_filter_tree/dos2unix.py
+++ b/git_filter_tree/dos2unix.py
@@ -14,6 +14,9 @@ Arguments:
 from .tree_filter import TreeFilter, cached
 
 import os
+import re
+
+TRAILING_WS = re.compile(br'[^\S\n]\n')
 
 class Dos2Unix(TreeFilter):
 
@@ -34,7 +37,7 @@ class Dos2Unix(TreeFilter):
 
     async def convertToUnix(self, obj):
         text = await self.read_blob(obj.sha1)
-        if len(text) == 0 or text[-1] == b'\n' and (len(text) == 1 or text[-2] != b'\n') and text.find(b"\r") == -1 and text.find(b" \n") == -1:
+        if not text or text.endswith(b'\n') and not text.endswith(b'\n\n') and not TRAILING_WS.search(text):
             return obj.sha1
         lines = text.splitlines()
         while len(lines) > 0 and lines[-1].rstrip() == b"":

--- a/git_filter_tree/dos2unix.py
+++ b/git_filter_tree/dos2unix.py
@@ -34,7 +34,7 @@ class Dos2Unix(TreeFilter):
 
     async def convertToUnix(self, obj):
         text = await self.read_blob(obj.sha1)
-        if text.find(b"\r") == -1 and text.find(b" \n") == -1:
+        if len(text) == 0 or text[-1] == b'\n' and (len(text) == 1 or text[-2] != b'\n') and text.find(b"\r") == -1 and text.find(b" \n") == -1:
             return obj.sha1
         lines = text.splitlines()
         while len(lines) > 0 and lines[-1].rstrip() == b"":


### PR DESCRIPTION
Only do the  split/join if we determine that it is needed, that is if the source file has a \r or has a line that ends with a space. This gives a significant speedup if most files do not need conversion.