### PR TITLE
Compare old sha1 against new sha1

### DIFF
--- a/git_filter_tree/tree_filter.py
+++ b/git_filter_tree/tree_filter.py
@@ -325,7 +325,7 @@ class TreeFilter(object):
             for ref in refs.splitlines():
                 old = self.repo.revparse_single(ref)
                 new = await self.rewrite_root(old.hex)
-                if old == new:
+                if old.hex == new:
                     print("WARNING: Ref {!r} is unchanged".format(ref))
                 else:
                     self.repo.references[ref].set_target(new, "tree-filter")


### PR DESCRIPTION
If we don't compare the sha1s against each other, then the commit is always different, and so logged as rewritten, even if it hasn't actually been changed.